### PR TITLE
Graceful fallback when glow is missing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,9 +14,11 @@
         "@biomejs/biome": "2.2.0",
         "@effect/experimental": "^0.54.6",
         "@effect/language-service": "^0.36.0",
+        "@effect/vitest": "^0.25.1",
         "@types/bun": "latest",
         "rolldown": "^1.0.0-beta.34",
         "ultracite": "5.2.4",
+        "vitest": "^3.2.4",
       },
       "peerDependencies": {
         "typescript": "^5.9.2",
@@ -69,6 +71,8 @@
     "@effect/sql": ["@effect/sql@0.44.2", "", { "dependencies": { "uuid": "^11.0.3" }, "peerDependencies": { "@effect/experimental": "^0.54.6", "@effect/platform": "^0.90.4", "effect": "^3.17.7" } }, "sha512-DEcvriHvj88zu7keruH9NcHQzam7yQzLNLJO6ucDXMCAwWzYZSJOsmkxBznRFv8ylFtccSclKH2fuj+wRKPjCQ=="],
 
     "@effect/typeclass": ["@effect/typeclass@0.36.0", "", { "peerDependencies": { "effect": "^3.17.0" } }, "sha512-+8xYvX4tjD7gKwGYzOyFh90I+ptdXzoNHLQTSa8kGh/xOVZMIGYb0VgLoNHE02UsuVrB+JJJuBmKLdd5TeDTPg=="],
+
+    "@effect/vitest": ["@effect/vitest@0.25.1", "", { "peerDependencies": { "effect": "^3.17.7", "vitest": "^3.2.0" } }, "sha512-OMYvOU8iGed8GZXxgVBXlYtjG+jwWj5cJxFk0hOHOfTbCHXtdCMEWlXNba5zxbE7dBnW4srbnSYrP/NGGTC3qQ=="],
 
     "@effect/workflow": ["@effect/workflow@0.9.2", "", { "peerDependencies": { "@effect/platform": "^0.90.5", "@effect/rpc": "^0.69.1", "effect": "^3.17.8" } }, "sha512-BQw2wVCCdhC0FgSQXL62sefa8TV3sVP0ECRZS9CGnUtiCZiVkRDEeQlXErZkKVuVhtAqJLfngqtp8UkArLPYiw=="],
 
@@ -420,7 +424,7 @@
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
-    "tinyexec": ["tinyexec@1.0.1", "", {}, "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw=="],
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
     "tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="],
 
@@ -466,11 +470,11 @@
 
     "node-gyp-build-optional-packages/detect-libc": ["detect-libc@2.0.4", "", {}, "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="],
 
+    "nypm/tinyexec": ["tinyexec@1.0.1", "", {}, "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw=="],
+
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "trpc-cli/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
-    "vitest/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
     "zod-to-json-schema/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
   }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "build": "rm -rf dist && rolldown src/index.ts --dir dist --minify",
     "dev": "bun src/index.ts",
     "fmt": "ultracite lint && ultracite format",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:cli": "bun run src/index.ts --help"
   },
   "engines": {
@@ -45,9 +47,11 @@
     "@biomejs/biome": "2.2.0",
     "@effect/experimental": "^0.54.6",
     "@effect/language-service": "^0.36.0",
+    "@effect/vitest": "^0.25.1",
     "@types/bun": "latest",
     "rolldown": "^1.0.0-beta.34",
-    "ultracite": "5.2.4"
+    "ultracite": "5.2.4",
+    "vitest": "^3.2.4"
   },
   "peerDependencies": {
     "typescript": "^5.9.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { Args, Command } from "@effect/cli";
 import { DevTools } from "@effect/experimental";
 import { BunContext, BunRuntime, BunSocket } from "@effect/platform-bun";
 import { FileStore } from "./lib/file-store";
-import { ConfigLive } from "./lib/config";
+import { Config } from "./lib/config";
 import { reduceDocument } from "./lib/document";
 import { Viewer } from "./lib/viewer";
 
@@ -24,8 +24,8 @@ function normalizeBunArgv(): string[] {
 
 const text = Args.text({ name: "text" }).pipe(Args.atLeast(1));
 
-const handleTask = (text: string[]) =>
-  Effect.gen(function* () {
+const handleTask = Effect.fn("handleTask")(
+  function* (text: string[]) {
     const store = yield* FileStore;
     const viewer = yield* Viewer;
     const { path, doc } = yield* store.loadTodayDocument;
@@ -35,7 +35,10 @@ const handleTask = (text: string[]) =>
     });
     yield* store.saveDocument(path, next);
     yield* viewer.showFile(path);
-  }).pipe(Effect.provide(FileStore.Default), Effect.provide(Viewer.Default));
+  },
+  Effect.provide(FileStore.Default),
+  Effect.provide(Viewer.Default)
+);
 
 const taskCommand = Command.make("task", { text }, ({ text }) => {
   return handleTask(text);
@@ -45,8 +48,8 @@ const taskShortCommand = Command.make("t", { text }, ({ text }) => {
   return handleTask(text);
 });
 
-const handleNote = (text: string[]) =>
-  Effect.gen(function* () {
+const handleNote = Effect.fn("handleNote")(
+  function* (text: string[]) {
     const store = yield* FileStore;
     const viewer = yield* Viewer;
     const { path, doc } = yield* store.loadTodayDocument;
@@ -56,7 +59,10 @@ const handleNote = (text: string[]) =>
     });
     yield* store.saveDocument(path, next);
     yield* viewer.showFile(path);
-  }).pipe(Effect.provide(FileStore.Default), Effect.provide(Viewer.Default));
+  },
+  Effect.provide(FileStore.Default),
+  Effect.provide(Viewer.Default)
+);
 
 const noteCommand = Command.make("note", { text }, ({ text }) => {
   return handleNote(text);
@@ -90,7 +96,7 @@ const cli = Command.run(command, {
   version: packageInfo.default.version,
 });
 
-const AppLayer = Layer.mergeAll(BunContext.layer, ConfigLive);
+const AppLayer = Layer.mergeAll(BunContext.layer, Config.Default);
 const DevToolsLive = DevTools.layerWebSocket().pipe(
   Layer.provide(BunSocket.layerWebSocketConstructor)
 );

--- a/src/lib/command-checker.ts
+++ b/src/lib/command-checker.ts
@@ -1,0 +1,21 @@
+import { Effect, Equal } from "effect";
+import { Command } from "@effect/platform";
+import { BunContext } from "@effect/platform-bun";
+
+export class CommandChecker extends Effect.Service<CommandChecker>()(
+  "tn/CommandChecker",
+  {
+    effect: Effect.gen(function* () {
+      return {
+        commandExists: Effect.fn("commandExists")(function* (cmd: string) {
+          const command = Command.make(cmd, "--version");
+          const exitCode = yield* Command.exitCode(command).pipe(
+            Effect.catchAll(() => Effect.succeed(1))
+          );
+          return Equal.equals(exitCode, 0);
+        }),
+      };
+    }),
+    dependencies: [BunContext.layer],
+  }
+) {}

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1,0 +1,42 @@
+import { it, expect } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import { detectViewer } from "./config";
+import { CommandChecker } from "./command-checker";
+// TODO: These tests need BunContext to be provided; why is that?
+import { BunContext } from "@effect/platform-bun";
+
+it.effect("prefers glow if available", () => {
+  const glowExistsChecker = Layer.mock(CommandChecker, {
+    _tag: "tn/CommandChecker",
+    commandExists: (cmd: string) => Effect.succeed(cmd === "glow"),
+  });
+
+  return Effect.gen(function* () {
+    const result = yield* detectViewer();
+    expect(result).toBe("glow");
+  }).pipe(Effect.provide(glowExistsChecker), Effect.provide(BunContext.layer));
+});
+
+it.effect("prefers bat if glow is not available", () => {
+  const batExistsChecker = Layer.mock(CommandChecker, {
+    _tag: "tn/CommandChecker",
+    commandExists: (cmd: string) => Effect.succeed(cmd === "bat"),
+  });
+
+  return Effect.gen(function* () {
+    const result = yield* detectViewer();
+    expect(result).toBe("bat");
+  }).pipe(Effect.provide(batExistsChecker), Effect.provide(BunContext.layer));
+});
+
+it.effect("falls back to cat if neither are available", () => {
+  const noExistsChecker = Layer.mock(CommandChecker, {
+    _tag: "tn/CommandChecker",
+    commandExists: (_cmd: string) => Effect.succeed(false),
+  });
+
+  return Effect.gen(function* () {
+    const result = yield* detectViewer();
+    expect(result).toBe("cat");
+  }).pipe(Effect.provide(noExistsChecker), Effect.provide(BunContext.layer));
+});

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -1,6 +1,6 @@
 import { Console, Effect } from "effect";
 import { Command } from "@effect/platform";
-import { Config, ConfigLive } from "./config";
+import { Config } from "./config";
 
 export class Viewer extends Effect.Service<Viewer>()("tn/Viewer", {
   effect: Effect.gen(function* () {
@@ -17,12 +17,12 @@ export class Viewer extends Effect.Service<Viewer>()("tn/Viewer", {
 
         yield* Command.exitCode(command);
       }).pipe(
-        Effect.catchAll(() => Console.log("showFile failed")),
+        Effect.catchAll((e) => Console.log(`showFile failed: ${String(e)}`)),
         Effect.withSpan("showFile")
       );
 
     return { showFile } as const;
   }),
 
-  dependencies: [ConfigLive],
+  dependencies: [Config.Default],
 }) {}


### PR DESCRIPTION
## Summary
- Handle spawn error when checking for glow so CLI no longer crashes if glow not installed.
- Fallback proceeds to bat or cat normally.

## Rationale
Previously a missing 'glow' binary caused an unhandled spawn error in ConfigLive, aborting startup before showing today's note. This change converts that failure into a non-zero exit code so detection logic can continue.

## Changes
- Wrap Command.exitCode in catchAll returning 1 in commandExists.

## Impact
- Users without glow now see their note rendered (via bat or cat) instead of an immediate crash.
- No behavioral change for users who have glow installed.

## Testing
- Ran 'bun dev' locally before: crashed.
- After change: shows file using bat (since glow absent).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Viewer detection is more robust to command invocation failures and reliably falls back to a safe default; file-show errors now include detailed error text.

* **New Features**
  * Introduced a command-probing service used to detect available viewer tools and exposed viewer detection for reuse.

* **Tests**
  * Added tests validating viewer selection across environments.

* **Chores**
  * Added test scripts and development testing dependencies.

* **Refactor**
  * Reworked configuration and handler wiring to a service-oriented pattern and updated application layer integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->