### PR TITLE
test: add CLI integration tests, test notes dir, devtools opt-in

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,12 +19,13 @@
         "@effect/language-service": "^0.36.0",
         "@effect/vitest": "^0.25.1",
         "@types/bun": "^1.2.22",
+        "@types/ws": "^8.18.1",
         "rolldown": "^1.0.0-beta.34",
         "ultracite": "5.4.5",
         "vitest": "^3.2.4",
       },
       "peerDependencies": {
-        "typescript": "^5.9.2",
+        "typescript": "^5.9.3",
       },
     },
   },
@@ -279,6 +280,8 @@
 
     "@types/react": ["@types/react@19.1.11", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-lr3jdBw/BGj49Eps7EvqlUaoeA0xpj3pc0RoJkHpYaCHkVK7i28dKyImLQb3JVlqs3aYSXf7qYuWOW/fgZnTXQ=="],
 
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
     "@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
@@ -441,7 +444,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "ultracite": ["ultracite@5.4.5", "", { "dependencies": { "@clack/prompts": "^0.11.0", "@trpc/server": "^11.5.1", "deepmerge": "^4.3.1", "jsonc-parser": "^3.3.1", "nypm": "^0.6.2", "trpc-cli": "^0.11.0", "vitest": "^3.2.4", "zod": "^4.1.11" }, "bin": { "ultracite": "dist/index.js" } }, "sha512-UWny94qR2w4I/hzX6zsAdK9GosnL3aNr7Yq21Ltgub/GmU9mriU8Us2M9AtiPCiGPVx1Ijn8hgn8/btDLDROTg=="],
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "rm -rf dist && rolldown src/index.ts --dir dist --minify",
     "dev": "bun src/index.ts",
     "fmt": "ultracite fix",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:cli": "bun run src/index.ts --help"
@@ -50,12 +51,11 @@
     "@effect/language-service": "^0.36.0",
     "@effect/vitest": "^0.25.1",
     "@types/bun": "^1.2.22",
+    "@types/ws": "^8.18.1",
     "rolldown": "^1.0.0-beta.34",
     "ultracite": "5.4.5",
-    "vitest": "^3.2.4"
-  },
-  "peerDependencies": {
-    "typescript": "^5.9.2"
+    "vitest": "^3.2.4",
+    "typescript": "^5.9.3"
   },
   "dependencies": {
     "@clack/prompts": "^0.11.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,12 +123,17 @@ const cli = Command.run(command, {
 })
 
 const AppLayer = Layer.mergeAll(BunContext.layer, Config.Default)
+const enableDevTools = process.env.TERMNOTES_DEVTOOLS === '1'
 const DevToolsLive = DevTools.layerWebSocket().pipe(Layer.provide(BunSocket.layerWebSocketConstructor))
 
-cli(normalizeBunArgv()).pipe(
+let program = cli(normalizeBunArgv()).pipe(
 	Effect.provide(AppLayer),
-	Effect.provide(DevToolsLive),
 	Effect.provide(CliConfig.layer({ showBuiltIns: false })),
 	Effect.tapErrorCause((cause) => Console.warn(`Error: ${String(cause)}`)),
-	BunRuntime.runMain,
 )
+
+if (enableDevTools) {
+	program = program.pipe(Effect.provide(DevToolsLive))
+}
+
+program.pipe(BunRuntime.runMain)

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -13,7 +13,11 @@ export class Config extends Effect.Service<Config>()('tn/Config', {
 }) {}
 
 const getNotesDir = Effect.fn('getNotesDir')(function* () {
-	// TODO: implement configuring this
+	// Use a separate local directory when running tests to avoid polluting real notes.
+	const env = process.env.NODE_ENV
+	if (env === 'test') {
+		return yield* Effect.succeed(`${process.cwd()}/.termnotes-test/notes`)
+	}
 	return yield* Effect.succeed(`${homedir()}/.termnotes/notes`)
 })()
 

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -5,16 +5,20 @@ import { Config } from './config'
 export class Viewer extends Effect.Service<Viewer>()('tn/Viewer', {
 	effect: Effect.gen(function* () {
 		const config = yield* Config
+		const disableViewer = process.env.TERMNOTES_NO_VIEWER === '1' || process.env.NODE_ENV === 'test'
 
 		const showFile = Effect.fn('showFile')(
 			function* (path: string) {
+				if (disableViewer) {
+					// Skip spawning external viewer in test / no-viewer mode.
+					return yield* Effect.void
+				}
 				const args = config.viewer === 'bat' ? ['--style=plain', path] : [path]
 				const command = Command.make(config.viewer, ...args).pipe(
 					Command.stdin('inherit'),
 					Command.stdout('inherit'),
 					Command.stderr('inherit'),
 				)
-
 				yield* Command.exitCode(command)
 			},
 			Effect.tapError((e) => Console.warn(`showFile failed: ${String(e)}`)),

--- a/tests/cli/basic.test.ts
+++ b/tests/cli/basic.test.ts
@@ -1,0 +1,153 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, describe, expect, test } from 'vitest'
+import { runCli } from '../utils/runCli'
+
+// Global cleanup for any stray project-level test directory.
+afterAll(() => {
+	try {
+		rmSync(join(process.cwd(), '.termnotes-test'), { recursive: true, force: true })
+	} catch {}
+})
+
+function todayNotePath(base: string) {
+	const today = new Date()
+	const yyyy = today.getFullYear()
+	const mm = String(today.getMonth() + 1).padStart(2, '0')
+	const dd = String(today.getDate()).padStart(2, '0')
+	return join(base, '.termnotes-test', 'notes', `${yyyy}-${mm}-${dd}.md`)
+}
+
+describe('tn CLI basic', () => {
+	test('running tn creates today note file', () => {
+		const tmp = mkdtempSync(join(tmpdir(), 'tn-test-'))
+		try {
+			const { status, stderr } = runCli([], { cwd: tmp })
+			expect(status, stderr).toBe(0)
+			const notePath = todayNotePath(tmp)
+			expect(existsSync(notePath)).toBe(true)
+			const content = readFileSync(notePath, 'utf-8')
+			expect(content).toContain('## Tasks')
+			expect(content).toContain('## Notes')
+		} finally {
+			rmSync(tmp, { recursive: true, force: true })
+		}
+	})
+
+	test('adding a single task appends to Tasks section', () => {
+		const tmp = mkdtempSync(join(tmpdir(), 'tn-test-'))
+		try {
+			// First ensure file exists
+			let result = runCli([], { cwd: tmp })
+			expect(result.status, result.stderr).toBe(0)
+			// Add task
+			result = runCli(['task', 'Write', 'tests'], { cwd: tmp })
+			expect(result.status, result.stderr).toBe(0)
+			const content = readFileSync(todayNotePath(tmp), 'utf-8')
+			expect(content).toMatch(/## Tasks\n- \[ \] Write tests\n?/) // task line present
+			expect(content).toContain('## Notes')
+		} finally {
+			rmSync(tmp, { recursive: true, force: true })
+		}
+	})
+
+	test('adding a single note appends to Notes section', () => {
+		const tmp = mkdtempSync(join(tmpdir(), 'tn-test-'))
+		try {
+			// Ensure file exists
+			let result = runCli([], { cwd: tmp })
+			expect(result.status, result.stderr).toBe(0)
+			// Add note
+			result = runCli(['note', 'Refactor', 'parser'], { cwd: tmp })
+			expect(result.status, result.stderr).toBe(0)
+			const content = readFileSync(todayNotePath(tmp), 'utf-8')
+			expect(content).toMatch(/## Notes[\s\S]*- Refactor parser/) // note line present somewhere after header
+			// Ensure tasks header still intact
+			expect(content).toContain('## Tasks')
+		} finally {
+			rmSync(tmp, { recursive: true, force: true })
+		}
+	})
+
+	test('adding then toggling a task updates its status', () => {
+		const tmp = mkdtempSync(join(tmpdir(), 'tn-test-'))
+		try {
+			// Ensure file exists
+			let result = runCli([], { cwd: tmp })
+			expect(result.status, result.stderr).toBe(0)
+			// Add task
+			result = runCli(['task', 'Toggle', 'me'], { cwd: tmp })
+			expect(result.status, result.stderr).toBe(0)
+			// Toggle task 1
+			result = runCli(['x', '1'], { cwd: tmp })
+			expect(result.status, result.stderr).toBe(0)
+			const content = readFileSync(todayNotePath(tmp), 'utf-8')
+			expect(content).toMatch(/## Tasks[\s\S]*- \[x\] Toggle me/)
+		} finally {
+			rmSync(tmp, { recursive: true, force: true })
+		}
+	})
+
+	test('adding both a task and a note includes both entries', () => {
+		const tmp = mkdtempSync(join(tmpdir(), 'tn-test-'))
+		try {
+			let result = runCli([], { cwd: tmp })
+			expect(result.status, result.stderr).toBe(0)
+			result = runCli(['task', 'Implement', 'feature'], { cwd: tmp })
+			expect(result.status, result.stderr).toBe(0)
+			result = runCli(['note', 'Review', 'design'], { cwd: tmp })
+			expect(result.status, result.stderr).toBe(0)
+			const content = readFileSync(todayNotePath(tmp), 'utf-8')
+			expect(content).toMatch(/## Tasks[\s\S]*- \[ \] Implement feature/)
+			expect(content).toMatch(/## Notes[\s\S]*- Review design/)
+		} finally {
+			rmSync(tmp, { recursive: true, force: true })
+		}
+	})
+
+	test('adding three tasks then toggling the second marks only that one done', () => {
+		const tmp = mkdtempSync(join(tmpdir(), 'tn-test-'))
+		try {
+			let result = runCli([], { cwd: tmp })
+			expect(result.status, result.stderr).toBe(0)
+			result = runCli(['task', 'First'], { cwd: tmp })
+			expect(result.status, result.stderr).toBe(0)
+			result = runCli(['task', 'Second'], { cwd: tmp })
+			expect(result.status, result.stderr).toBe(0)
+			result = runCli(['task', 'Third'], { cwd: tmp })
+			expect(result.status, result.stderr).toBe(0)
+			result = runCli(['x', '2'], { cwd: tmp })
+			expect(result.status, result.stderr).toBe(0)
+			const content = readFileSync(todayNotePath(tmp), 'utf-8')
+			// Expect tasks in order with only second marked x
+			expect(content).toMatch(/## Tasks[\s\S]*- \[ \] First[\s\S]*- \[x\] Second[\s\S]*- \[ \] Third/)
+		} finally {
+			rmSync(tmp, { recursive: true, force: true })
+		}
+	})
+
+	test('toggling an invalid index leaves tasks unchanged', () => {
+		const tmp = mkdtempSync(join(tmpdir(), 'tn-test-'))
+		try {
+			let result = runCli([], { cwd: tmp })
+			expect(result.status, result.stderr).toBe(0)
+			result = runCli(['task', 'First'], { cwd: tmp })
+			expect(result.status, result.stderr).toBe(0)
+			result = runCli(['task', 'Second'], { cwd: tmp })
+			expect(result.status, result.stderr).toBe(0)
+			result = runCli(['task', 'Third'], { cwd: tmp })
+			expect(result.status, result.stderr).toBe(0)
+			// Attempt to toggle non-existent 4th task
+			result = runCli(['x', '4'], { cwd: tmp })
+			expect(result.status, result.stderr).toBe(0) // still succeeds with warning
+			const content = readFileSync(todayNotePath(tmp), 'utf-8')
+			expect(content).toMatch(/- \[ \] First/)
+			expect(content).toMatch(/- \[ \] Second/)
+			expect(content).toMatch(/- \[ \] Third/)
+			expect(content).not.toMatch(/- \[x\]/)
+		} finally {
+			rmSync(tmp, { recursive: true, force: true })
+		}
+	})
+})

--- a/tests/utils/runCli.ts
+++ b/tests/utils/runCli.ts
@@ -1,0 +1,18 @@
+import { spawnSync } from 'node:child_process'
+import { join } from 'node:path'
+
+export interface CliRunResult {
+	status: number | null
+	stdout: string
+	stderr: string
+}
+
+export function runCli(args: string[], opts: { cwd: string; env?: Record<string, string> }): CliRunResult {
+	const entry = join(process.cwd(), 'src', 'index.ts')
+	const proc = spawnSync('bun', ['run', entry, ...args], {
+		cwd: opts.cwd,
+		env: { ...process.env, NODE_ENV: 'test', TERMNOTES_NO_VIEWER: '1', ...opts.env },
+		encoding: 'utf-8',
+	})
+	return { status: proc.status, stdout: proc.stdout, stderr: proc.stderr }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     "paths": {
       "@/lib/*": ["src/lib/*"]
     },
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "skipLibCheck": true
   },
   "plugins": [
     {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+	test: {
+		include: ['src/**/*.test.ts', 'tests/**/*.test.ts'],
+	},
+})


### PR DESCRIPTION
@coderabbitai


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Optional DevTools mode enabled via an environment flag.
  - Option to disable the external viewer via an environment flag or in test mode.

- Refactor
  - Startup flow updated so DevTools integration is applied conditionally while preserving prior behavior when disabled.

- Tests
  - Added comprehensive CLI test suite and a test helper for isolated runs.
  - Added test runner configuration to locate tests.

- Chores
  - Test runs use a dedicated test notes directory.
  - Added a typecheck script and updated developer tooling dependencies and config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->